### PR TITLE
uses bundled (embeded in mysql code base) OpenSSL

### DIFF
--- a/mysql56-with-q4m.rb
+++ b/mysql56-with-q4m.rb
@@ -63,8 +63,7 @@ class Mysql56WithQ4m < Formula
       -DINSTALL_DOCDIR=share/doc/#{name}
       -DINSTALL_INFODIR=share/info
       -DINSTALL_MYSQLSHAREDIR=share/mysql
-      -DWITH_SSL=yes
-      -DWITH_SSL=system
+      -DWITH_SSL=bundled
       -DDEFAULT_CHARSET=utf8
       -DDEFAULT_COLLATION=utf8_general_ci
       -DSYSCONFDIR=#{etc}


### PR DESCRIPTION
Recently `cmake` command has failed do to OpenSSL library issue.

`-DWITH_SSL=bundled` option means using embedded OpenSSL library in mysql-5.6.22 code base.
