### PR TITLE
Fix cdn url of mysqld

### DIFF
--- a/mysql56-with-q4m.rb
+++ b/mysql56-with-q4m.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Mysql56WithQ4m < Formula
   homepage "http://dev.mysql.com/doc/refman/5.6/en/"
-  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.28.tar.gz"
+  url "https://cdn.mysql.com/archives/mysql-5.6/mysql-5.6.28.tar.gz"
   sha256 "217cd96921abdd709b9b4ff3ce2af4cbd237de43679cf19385d19df03a037b21"
 
   bottle do


### PR DESCRIPTION
 I've checked that the checksum is the same as the previous url's. 

$ wget http://cdn.mysql.com/archives/mysql-5.6/mysql-5.6.28.tar.gz
$ shasum -a 256 mysql-5.6.28.tar.gz
217cd96921abdd709b9b4ff3ce2af4cbd237de43679cf19385d19df03a037b21  mysql-5.6.28.tar.gz
