### PR TITLE
Use sha256 because calling resource#sha1 is deprecated

### DIFF
--- a/mysql56-with-q4m.rb
+++ b/mysql56-with-q4m.rb
@@ -14,7 +14,7 @@ class Mysql56WithQ4m < Formula
   resource 'q4m' do
     url 'http://q4m.kazuhooku.com/dist/q4m-0.9.14.tar.gz'
     version '0.9.14'
-    sha1 '7d865bd6588923fcf867e361eba99585d009d66a'
+    sha256 '26f6242fb56580a3bd16fd025012fac3b264be6269255532d1398273b1d7792a'
   end
 
   option :universal


### PR DESCRIPTION
@SpringMT 

Hi.

These days Homebrew warns about using Resource#sha1:

```
Warning: Calling Resource#sha1 is deprecated!
Use Resource#sha256 instead.
/Users/key-amb/Library/Caches/Homebrew/Formula/mysql56-with-q4m.rb:17:in `block in <class:Mysql56WithQ4m>'
```

So I replaced it with `#sha256`.

```
/tmp% shasum q4m-0.9.14.tar.gz 
7d865bd6588923fcf867e361eba99585d009d66a  q4m-0.9.14.tar.gz
/tmp% shasum -a 256 q4m-0.9.14.tar.gz                                                                                                       
26f6242fb56580a3bd16fd025012fac3b264be6269255532d1398273b1d7792a  q4m-0.9.14.tar.gz
```

I'm happy if you take care of this.

Thanks.
