### PR TITLE
Fix cdn url of mysqld57

### DIFF
--- a/mysql57-with-q4m.rb
+++ b/mysql57-with-q4m.rb
@@ -3,7 +3,7 @@ require "formula"
 class Mysql57WithQ4m < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.7/en/"
-  url "https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-boost-5.7.32.tar.gz"
+  url "https://cdn.mysql.com/archives/mysql-5.7/mysql-boost-5.7.32.tar.gz"
   sha256 "9a8a04a2b0116ccff9a8d8aace07aaeaacf47329b701c5dfa9fa4351d3f1933b"
 
   resource 'q4m' do


### PR DESCRIPTION
I've checked that the checksum is the same as the previous url's.

$ wget https://cdn.mysql.com/archives/mysql-5.7/mysql-boost-5.7.32.tar.gz
$ shasum -a 256 mysql-boost-5.7.32.tar.gz
9a8a04a2b0116ccff9a8d8aace07aaeaacf47329b701c5dfa9fa4351d3f1933b  mysql-boost-5.7.32.tar.gz
